### PR TITLE
Added option to skip hidden rows

### DIFF
--- a/Npoi.Mapper/src/Npoi.Mapper/Mapper.cs
+++ b/Npoi.Mapper/src/Npoi.Mapper/Mapper.cs
@@ -134,6 +134,14 @@ namespace Npoi.Mapper
         /// </value>
         public bool SkipWriteDefaultValue { get; set; } = false;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip hidden rows when reading from Excel files. Default is false.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if hidden lines are skipped; otherwise, <c>false</c>.
+        /// </value>
+        public bool SkipHiddenRows { get; set; } = false;
+
         #endregion
 
         #region Constructors
@@ -601,6 +609,7 @@ namespace Npoi.Mapper
                 if (maxErrorRows > 0 && errorCount >= maxErrorRows) break;
                 if (row.RowNum < firstDataRowIndex) continue;
 
+                if (SkipHiddenRows && row.Hidden.HasValue && row.Hidden.Value) continue;
                 if (SkipBlankRows && row.Cells.All(c => IsCellBlank(c))) continue;
 
                 var obj = objectInitializer == null ? Activator.CreateInstance(targetType) : objectInitializer();

--- a/Npoi.Mapper/test/ImportGeneralTests.cs
+++ b/Npoi.Mapper/test/ImportGeneralTests.cs
@@ -608,6 +608,37 @@ namespace test
         }
 
         [Test]
+        public void Take_SkipHiddenRows_True()
+        {
+            // Arrange
+            const string value = "dummy";
+            const string hiddenValue = "hidden dummy";
+            var workbook = GetBlankWorkbook();
+            var sheet = workbook.GetSheetAt(0);
+            sheet.CreateRow(0);
+            sheet.CreateRow(1);
+            sheet.CreateRow(2);
+
+            sheet.GetRow(0).CreateCell(0).SetCellValue(nameof(TestClass.String).ToUpperInvariant());
+            sheet.GetRow(1).CreateCell(0).SetCellValue(value);
+            sheet.GetRow(2).CreateCell(0).SetCellValue(hiddenValue);
+            sheet.GetRow(2).Hidden = true;
+
+            var mapper = new Mapper(workbook)
+            {
+                SkipHiddenRows = true,
+            };
+
+            // Act
+            var items = mapper.Take<TestClass>().ToList();
+
+            // Assert
+            Assert.AreEqual(1, items.Count);
+            Assert.AreEqual(value, items[0].Value.String);
+        }
+
+
+        [Test]
         public void Take_DateTime_And_DateTimeOffice()
         {
             // Arrange

--- a/Npoi.Mapper/test/ImportGeneralTests.cs
+++ b/Npoi.Mapper/test/ImportGeneralTests.cs
@@ -619,7 +619,7 @@ namespace test
             sheet.CreateRow(1);
             sheet.CreateRow(2);
 
-            sheet.GetRow(0).CreateCell(0).SetCellValue(nameof(TestClass.String).ToUpperInvariant());
+            sheet.GetRow(0).CreateCell(0).SetCellValue(nameof(TestClass.String));
             sheet.GetRow(1).CreateCell(0).SetCellValue(value);
             sheet.GetRow(2).CreateCell(0).SetCellValue(hiddenValue);
             sheet.GetRow(2).Hidden = true;
@@ -637,6 +637,33 @@ namespace test
             Assert.AreEqual(value, items[0].Value.String);
         }
 
+        [Test]
+        public void Take_SkipHiddenRows_False()
+        {
+            // Arrange
+            const string value = "dummy";
+            const string hiddenValue = "hidden dummy";
+            var workbook = GetBlankWorkbook();
+            var sheet = workbook.GetSheetAt(0);
+            sheet.CreateRow(0);
+            sheet.CreateRow(1);
+            sheet.CreateRow(2);
+
+            sheet.GetRow(0).CreateCell(0).SetCellValue(nameof(TestClass.String));
+            sheet.GetRow(1).CreateCell(0).SetCellValue(value);
+            sheet.GetRow(2).CreateCell(0).SetCellValue(hiddenValue);
+            sheet.GetRow(2).Hidden = true;
+
+            var mapper = new Mapper(workbook);
+
+            // Act
+            var items = mapper.Take<TestClass>().ToList();
+
+            // Assert
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual(value, items[0].Value.String);
+            Assert.AreEqual(hiddenValue, items[1].Value.String);
+        }
 
         [Test]
         public void Take_DateTime_And_DateTimeOffice()


### PR DESCRIPTION
Great project, I'm using it a lot! I've noticed that there's an option to skip blank rows (`SkipBlankRows`), but no option to skip rows which were hidden. It would help me greatly with my projects if such option would be available, so I've taken a liberty to add `SkipHiddenRows`. I've also modified `private IEnumerable<RowInfo<T>> Take<T>(Func<ICell, Type> getColumnType, ISheet sheet, int maxErrorRows, Func<T> objectInitializer = null)` accordingly and added two tests (`Take_SkipHiddenRows_True` and `Take_SkipHiddenRows_False`).

Hope you'll find it useful and would decide to merge it into your project.