### PR TITLE
returns null instead of empty string for blank cells

### DIFF
--- a/Npoi.Mapper/src/Npoi.Mapper/MapHelper.cs
+++ b/Npoi.Mapper/src/Npoi.Mapper/MapHelper.cs
@@ -340,7 +340,9 @@ public class MapHelper
 
         if (targetType == StringType && cellType != CellType.Blank)
         {
-            value = TrimString(CellDataFormatter.FormatCellValue(cell, evaluator));
+            string trimmedValue = TrimString(CellDataFormatter.FormatCellValue(cell, evaluator));
+            value = trimmedValue?.Length == 0 ? null : trimmedValue;
+
             return true;
         }
 

--- a/Npoi.Mapper/src/Npoi.Mapper/MapHelper.cs
+++ b/Npoi.Mapper/src/Npoi.Mapper/MapHelper.cs
@@ -336,7 +336,9 @@ public class MapHelper
         value = null;
         if (cell == null) return true;
 
-        if (targetType == StringType)
+        var cellType = GetCellType(cell);
+
+        if (targetType == StringType && cellType != CellType.Blank)
         {
             value = TrimString(CellDataFormatter.FormatCellValue(cell, evaluator));
             return true;
@@ -361,7 +363,7 @@ public class MapHelper
             }
         }
 
-        switch (GetCellType(cell))
+        switch (cellType)
         {
             case CellType.String:
 

--- a/Npoi.Mapper/test/NestedPropertyTests.cs
+++ b/Npoi.Mapper/test/NestedPropertyTests.cs
@@ -89,9 +89,9 @@ public class NestedPropertyTests : TestBase
         Assert.AreEqual(addressId, objs[0].Value.Billing.Address.AddressId);
         Assert.AreEqual(date.Date, objs[0].Value.Billing.Dates.Dto.Date);
 
-        Assert.AreEqual("", objs[1].Value.Name);
+        Assert.AreEqual(null, objs[1].Value.Name);
         Assert.AreEqual(customerAge, objs[1].Value.Age);
-        Assert.AreEqual("", objs[1].Value.Billing.Contact.Name);
+        Assert.AreEqual(null, objs[1].Value.Billing.Contact.Name);
         Assert.AreEqual(null, objs[1].Value.Billing.Address);
         Assert.AreEqual(DateTime.MinValue, objs[1].Value.Billing.Dates.Dto.Date);
     }


### PR DESCRIPTION
Hi,

This PR solves issue #129 , the main idea is to revert behavior of returning null value when blank cell is mapped to string property. Current behavior returns string.Empty which is a breaking change.

Can you please keep previous behavior, all my code is based on that assumption :).

Thanks and best regards
@POFerro 
